### PR TITLE
Send etag on upload

### DIFF
--- a/lib/nightcrawler_swift/upload.rb
+++ b/lib/nightcrawler_swift/upload.rb
@@ -1,9 +1,13 @@
+require 'digest'
+
 module NightcrawlerSwift
   class Upload < Command
 
     def execute path, file
       content_type = MultiMime.by_file(file).content_type
-      response = put "#{connection.upload_url}/#{path}", body: file.read, headers: {content_type: content_type}
+      content = file.read
+      etag = '"%s"' % Digest::MD5.new.update(content).hexdigest
+      response = put "#{connection.upload_url}/#{path}", body: content, headers: {etag: etag, content_type: content_type}
       [200, 201].include?(response.code)
     end
 

--- a/spec/lib/nightcrawler_swift/upload_spec.rb
+++ b/spec/lib/nightcrawler_swift/upload_spec.rb
@@ -1,3 +1,4 @@
+require 'digest'
 require 'spec_helper'
 
 describe NightcrawlerSwift::Upload do
@@ -41,9 +42,10 @@ describe NightcrawlerSwift::Upload do
       expect(subject).to have_received(:put).with(anything, hash_including(body: "content"))
     end
 
-    it "sends file content_type as header" do
+    it "sends file metadata as headers" do
       execute
-      expect(subject).to have_received(:put).with(anything, hash_including(headers: { content_type: "text/css"}))
+      etag = '"%s"' % Digest::MD5.new.update(file.read).hexdigest
+      expect(subject).to have_received(:put).with(anything, hash_including(headers: { content_type: "text/css", etag: etag}))
     end
 
     it "sends to upload url with given path" do


### PR DESCRIPTION
This way, Swift can detect if the file's contents were corrupted in
transit and react appropriately (a 422 Unprocessable Entity response).

This protects the files from both accidental corruption from a noisy channel and from deliberate\* corruption from, say, the awful proxy server that your company*\* forces all HTTP and HTTPS traffic to go through.

For reference, docs for object PUT are here (search for "ETag"): http://docs.openstack.org/api/openstack-object-storage/1.0/content/PUT_createOrReplaceObject__v1__account___container___object__storage_object_services.html#PUT_createOrReplaceObject__v1__account___container___object__storage_object_services-Request

\* stupidity? malice? who can say?

** not my company, thankfully, but I know people saddled with these
