### PR TITLE
Exclude Expires header

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+  - Added support for custom headers
+
 ## 0.9.0
 
   - Added support for content-encoding option

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+
+  - Exclude ```Expires``` header
+
 ## 0.10.0
 
   - Added support for custom headers

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.10.1
+## 0.11.0
 
-  - Exclude ```Expires``` header
+  - Exclude ```Expires``` header when max-age used
+  - Add ```Expires``` header as an independent option
 
 ## 0.10.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nightcrawler_swift (0.10.0)
+    nightcrawler_swift (0.10.1)
       concurrent-ruby (~> 0.8.0)
       multi_mime (>= 1.0.1)
       rest-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nightcrawler_swift (0.9.0)
+    nightcrawler_swift (0.10.0)
       concurrent-ruby (~> 0.8.0)
       multi_mime (>= 1.0.1)
       rest-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nightcrawler_swift (0.10.1)
+    nightcrawler_swift (0.11.0)
       concurrent-ruby (~> 0.8.0)
       multi_mime (>= 1.0.1)
       rest-client
@@ -48,6 +48,7 @@ GEM
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.6.0)
+    timecop (0.8.0)
 
 PLATFORMS
   ruby
@@ -59,3 +60,4 @@ DEPENDENCIES
   nightcrawler_swift!
   rake
   rspec
+  timecop

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ config.nightcrawler_swift.ssl_ca_file = "ca_certificate.pem"
 
 #default: nil
 config.nightcrawler_swift.ssl_version = "SSLv23"
+
+#default: {}
+config.nightcrawler_swift.custom_headers = {custom_header: 'custom_value'}
 ```
 
 By default it will use ```Rails.logger``` as logger, to change that use a different logger in configurations, like:
@@ -102,6 +105,10 @@ The number of times to retry the request before failing. To disable this feature
 > max_retry_time
 
 Maximum delay in seconds between each retry. The delay will start with 1s and will double for each retry until this value.
+
+> custom_headers
+
+Optional hash with header fields to be uploaded with the object.
 
 #### 2) Profit!
 
@@ -159,6 +166,9 @@ ssl_client_key:
 
 # default: nil
 ssl_ca_file: "ca_certificate.pem"
+
+# default: {}
+custom_headers: {custom_header: 'custom_value'}
 ```
 
 By default it will use ```Logger.new(STDOUT)``` as logger, to change that use:

--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ config.nightcrawler_swift.logger = Logger.new(STDOUT)
 
 Defines the *Cache-Control:max-age=<value>* header.
 
+> expires
+
+Defines the *Expires* header.
+
 > content_encoding
 
 Defines the *Content-Encoding:<vaule>* header

--- a/lib/nightcrawler_swift.rb
+++ b/lib/nightcrawler_swift.rb
@@ -1,4 +1,3 @@
-require "cgi"
 require "date"
 require "json"
 require "logger"

--- a/lib/nightcrawler_swift/commands/upload.rb
+++ b/lib/nightcrawler_swift/commands/upload.rb
@@ -8,6 +8,9 @@ module NightcrawlerSwift
       max_age = opts[:max_age] || options.max_age
       headers.merge!(cache_control: "public, max-age=#{max_age}") if max_age
 
+      expires = opts[:expires]
+      headers.merge!(expires: CGI.rfc1123_date(expires)) if expires
+
       content_encoding = opts[:content_encoding] || options.content_encoding
       headers.merge!(content_encoding: content_encoding.to_s) if content_encoding
 

--- a/lib/nightcrawler_swift/commands/upload.rb
+++ b/lib/nightcrawler_swift/commands/upload.rb
@@ -6,7 +6,7 @@ module NightcrawlerSwift
       headers = {etag: etag(body), content_type: content_type(file)}
 
       max_age = opts[:max_age] || options.max_age
-      headers.merge!(cache_control: "public, max-age=#{max_age}", expires: expires(max_age)) if max_age
+      headers.merge!(cache_control: "public, max-age=#{max_age}") if max_age
 
       content_encoding = opts[:content_encoding] || options.content_encoding
       headers.merge!(content_encoding: content_encoding.to_s) if content_encoding
@@ -26,10 +26,6 @@ module NightcrawlerSwift
 
     def etag content
       Digest::MD5.hexdigest(content)
-    end
-
-    def expires max_age
-      CGI.rfc1123_date(Time.now + max_age)
     end
 
   end

--- a/lib/nightcrawler_swift/version.rb
+++ b/lib/nightcrawler_swift/version.rb
@@ -1,3 +1,3 @@
 module NightcrawlerSwift
-  VERSION = "0.10.1"
+  VERSION = "0.11.0"
 end

--- a/lib/nightcrawler_swift/version.rb
+++ b/lib/nightcrawler_swift/version.rb
@@ -1,3 +1,3 @@
 module NightcrawlerSwift
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end

--- a/lib/nightcrawler_swift/version.rb
+++ b/lib/nightcrawler_swift/version.rb
@@ -1,3 +1,3 @@
 module NightcrawlerSwift
-  VERSION = "0.9.0"
+  VERSION = "0.10.0"
 end

--- a/nightcrawler_swift.gemspec
+++ b/nightcrawler_swift.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "timecop"
 
   if RUBY_VERSION =~ /1\.9/
     spec.add_development_dependency "debugger"

--- a/spec/lib/nightcrawler_swift/commands/upload_spec.rb
+++ b/spec/lib/nightcrawler_swift/commands/upload_spec.rb
@@ -113,6 +113,28 @@ describe NightcrawlerSwift::Upload do
       end
     end
 
+    context "expires" do
+      let :default_headers do
+        {content_type: "text/css", etag: etag}
+      end
+      let(:timestamp) { "Tue, 08 Dec 2015 17:03:31 GMT" }
+
+      it "allows custom content_encoding" do
+        time = Time.parse(timestamp)
+
+        Timecop.freeze(time) do
+          NightcrawlerSwift.configure
+          subject.execute path, file, expires: time
+          expect(subject).to have_received(:put).with(
+            anything,
+            hash_including(
+              headers: hash_including(expires: timestamp)
+            )
+          )
+        end
+      end
+    end
+
     context "content_encoding" do
       let :default_headers do
         {content_type: "text/css", etag: etag}

--- a/spec/lib/nightcrawler_swift/commands/upload_spec.rb
+++ b/spec/lib/nightcrawler_swift/commands/upload_spec.rb
@@ -94,21 +94,6 @@ describe NightcrawlerSwift::Upload do
           )
         )
       end
-
-      it "also sends the expires header based on max_age" do
-        now = Time.now
-        allow(Time).to receive(:now).and_return(now)
-        expires = CGI.rfc1123_date(Time.now + max_age)
-
-        NightcrawlerSwift.configure max_age: max_age
-        execute
-        expect(subject).to have_received(:put).with(
-          anything,
-          hash_including(
-            headers: default_headers.merge(cache_control: "public, max-age=#{max_age}", expires:  expires)
-          )
-        )
-      end
     end
 
     context "custom_headers" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
 require "rake"
+require "timecop"
 RUBY_VERSION =~ /1\.9/ ? require("debugger") : require("byebug")
 require "nightcrawler_swift"
 


### PR DESCRIPTION
This branch aims to exclude ```Expires``` header, as it is redudant to ```Cache-Control``` header. In fact, the gem is uploading an object with a metadata field named ```Expires```, which will always have the same value it had when the object was uploaded. ```Expires``` header doesn't get updated when the object is served by Swift server.