### PR TITLE
Remove warnings

### DIFF
--- a/lib/nightcrawler_swift.rb
+++ b/lib/nightcrawler_swift.rb
@@ -26,7 +26,7 @@ require "nightcrawler_swift/railtie" if defined?(Rails)
 module NightcrawlerSwift
   class << self
 
-    attr_accessor :logger
+    attr_writer :logger
     attr_reader :options, :connection
 
     def logger

--- a/lib/nightcrawler_swift/connection.rb
+++ b/lib/nightcrawler_swift/connection.rb
@@ -16,6 +16,7 @@ module NightcrawlerSwift
     connected_attr_reader :catalog, :admin_url, :upload_url, :public_url, :internal_url
 
     def auth_response
+      @auth_response ||= nil
       authenticate! if @auth_response.nil?
       @auth_response
     end


### PR DESCRIPTION
Two simple changes to avoid boring warnings:

Running tests with `RUBYOPT=-w` before the changes:

```
Ruby Warnings found:

  20 lib/nightcrawler_swift/connection.rb:20: warning: instance variable @auth_response not initialized
  20 lib/nightcrawler_swift/connection.rb:19: warning: instance variable @auth_response not initialized
   1 lib/nightcrawler_swift.rb:32: warning: method redefined; discarding old logger
```